### PR TITLE
이미 존재하던 회원을 로그인 없이 수정할 수 있던 취약점 해결

### DIFF
--- a/src/main/java/onboarding/crud/user/controller/UserController.java
+++ b/src/main/java/onboarding/crud/user/controller/UserController.java
@@ -38,7 +38,7 @@ public class UserController{
             return ResponseEntity.ok(userService.registerUser(user));
         } catch (Exception e) {
             throw new ResponseStatusException(
-                HttpStatus.INTERNAL_SERVER_ERROR, "회원가입 중 오류가 발생했습니다."
+                HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()
             );
         }
     }

--- a/src/main/java/onboarding/crud/user/service/UserService.java
+++ b/src/main/java/onboarding/crud/user/service/UserService.java
@@ -23,7 +23,10 @@ public class UserService {
         return userRepository.findById(userId);
     }
 
-    public User registerUser(User user) {
+    public User registerUser(User user) throws Exception{
+        if(userRepository.existsById(user.getId())){
+            throw new Exception("이미 존재하는 회원입니다.");
+        }
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
UserRepository.save를 호출할때 실제로 그 save함수를 구현하는 SimpleJpaRepository 코드를 보게되면,

저장하려는 엔티티가 새것일 때에는 insert, 
이미 있다면 update합니다.

따라서 그전까지 signup 엔드포인트에 id를 함께 넣어 회원가입 요청을 날리면,
기존에 있던 유저 정보를 아무런 인증절차 없이 변경할 수 있었습니다.

UserService쪽에 existsById()를 사용하여 한번 더 검증하게 만들어서 해결했습니다.

+ exists() 메서드를 바로 활용하고 싶었는데
Inferred type 'S' for type parameter 'S' is not within its bound; should extend 'onboarding.crud.user.entity.User'
이러한 에러가 발생했습니다. 해결 방법을 아시는분은 커밋하면서 알려주시기 바랍니다.